### PR TITLE
Fix BERT cache path

### DIFF
--- a/models/deep_learning_classifier.py
+++ b/models/deep_learning_classifier.py
@@ -13,7 +13,7 @@ from sklearn.metrics import classification_report, accuracy_score
 import warnings
 import json
 import datetime
-import pickle
+from src.config.settings import Settings
 warnings.filterwarnings('ignore')
 
 from .model_manager import ModelManager
@@ -71,7 +71,7 @@ class DeepLearningClassifier:
         # Inicializar el gestor de modelos
         self.model_manager = ModelManager()
         self.model_dir = self.model_manager.deep_models_dir
-        self.bert_cache_dir = os.path.join(self.model_dir, 'bert_cache')
+        self.bert_cache_dir = Settings.BERT_CACHE_DIR
         os.makedirs(self.bert_cache_dir, exist_ok=True)
     
     def check_dependencies(self, model_type):

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -32,4 +32,4 @@ class Settings:
         for directory in directories:
             directory.mkdir(parents=True, exist_ok=True)
             
-        return True 
+        return True


### PR DESCRIPTION
## Summary
- load settings in `DeepLearningClassifier`
- store BERT cache using the central path from `Settings`
- ensure newline at end of `settings.py`

## Testing
- `python -m py_compile models/deep_learning_classifier.py src/config/settings.py`

------
https://chatgpt.com/codex/tasks/task_e_684458a82f3c832ca3e4a75f6a010918