### PR TITLE
Corregir importaciones relativas en módulos de postulación

### DIFF
--- a/page/postulacion_api.py
+++ b/page/postulacion_api.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify, request, send_file
-from postulacion_backend import PostulacionManager
-from postulacion_extension import add_classification_columns
+# Importaciones relativas para evitar problemas de rutas
+from .postulacion_backend import PostulacionManager
+from .postulacion_extension import add_classification_columns
 from flask_cors import CORS
 from io import BytesIO
 import joblib

--- a/page/postulacion_backend.py
+++ b/page/postulacion_backend.py
@@ -1,6 +1,14 @@
 import os
 import re
-from postulacion_db import init_database, add_postulacion, get_all_postulaciones, get_postulacion_by_id, get_cv_data, delete_postulacion_from_db
+# Importaciones relativas para mantener la coherencia del paquete
+from .postulacion_db import (
+    init_database,
+    add_postulacion,
+    get_all_postulaciones,
+    get_postulacion_by_id,
+    get_cv_data,
+    delete_postulacion_from_db,
+)
 
 class PostulacionManager:
     """Clase para manejar las operaciones de postulación."""


### PR DESCRIPTION
## Resumen
- ajustar las importaciones en `postulacion_api.py` y `postulacion_backend.py`
- usar rutas relativas para que Python encuentre los módulos correctos

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844727405d4832ca780dfa1bb51394c